### PR TITLE
Use setup-node node-version-file detection

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,11 +8,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - id: read_node_version
-      run: echo "version=$(cat .node-version)" >> $GITHUB_OUTPUT
-      shell: bash
     - uses: actions/setup-node@v3
       with:
-        node-version: ${{ steps.read_node_version.outputs.version }}
+        node-version-file: .node-version
     - run: npm install ${{ inputs.environment == 'production' && '--omit=dev' || '' }}
       shell: bash


### PR DESCRIPTION
Updates the shared setup action to delegate to setup-node to read the version file
